### PR TITLE
Allow non-existent options to be monitored.

### DIFF
--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -100,8 +100,8 @@ class Plugin {
 	 */
 	public function monitor_option_accesses( $tag ) {
 		// Check if the tag is related to an option access.
-		if ( strpos( $tag, 'option_' ) === 0 ) {
-			$option_name = substr( $tag, strlen( 'option_' ) );
+		if ( str_starts_with( $tag, 'option_' ) || str_starts_with( $tag, 'default_option_' ) ) {
+			$option_name = preg_replace( '#^(default_)?option_#', '', $tag );
 			$this->add_option_usage( $option_name );
 		}
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

This fixes the monitoring of non-existent options. WordPress triggers a [different filter](https://github.com/WordPress/WordPress/blob/414951bc877589f671b0367918069166304662c2/wp-includes/option.php#L199) when an option doesn't exist. The same filter is used again on lines [217](https://github.com/WordPress/WordPress/blob/414951bc877589f671b0367918069166304662c2/wp-includes/option.php#L217) and [230](https://github.com/WordPress/WordPress/blob/414951bc877589f671b0367918069166304662c2/wp-includes/option.php#L230).

Very cool plugin! I was about to build something very similar before I stumbled on this.

## Summary

This PR can be summarized in the following changelog entry:

* Fix monitoring of non-existent options.

## Relevant technical choices:

* `str_starts_with()` is a little easier to read, but is PHP 8+ if that's relevant.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] I have checked that the base branch is correctly set.

Fixes #
