### PR TITLE
Fix JS error when option is deleted

### DIFF
--- a/js/admin-script.js
+++ b/js/admin-script.js
@@ -237,7 +237,7 @@ jQuery( document ).ready(
 		 */
 		function updateRowOnSuccess(response, table, optionName, action) {
 			if ( action === 'delete-option' || action === 'create-option-false' ) {
-				table.row( 'tr#option_' + optionName ).remove().draw( 'page' );
+				table.row( 'tr#option_' + optionName ).remove().draw( 'full-hold' );
 			} else if ( action === 'add-autoload' || action === 'remove-autoload' ) {
 				const autoloadStatus = action === 'add-autoload' ? 'yes' : 'no';
 				const buttonHTML     = action === 'add-autoload' ?


### PR DESCRIPTION
## Context

When option is deleted there is a Javascript error in the browser console:

```
Uncaught TypeError: Cannot read properties of null (reading 'nTr')
    at S (datatables.min.js?ver=2.0.1:16:25194)
    at U.<anonymous> (datatables.min.js?ver=2.0.1:16:51287)
    at U.iterator (datatables.min.js?ver=2.0.1:16:46398)
    at U.<anonymous> (datatables.min.js?ver=2.0.1:16:51247)
    at U.draw (datatables.min.js?ver=2.0.1:16:47678)
    at updateRowOnSuccess (admin-script.js?ver=1741843012:240:53)
    at Object.success (admin-script.js?ver=1741843012:221:27)
    at c (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils&ver=6.7.2:2:25304)
    at Object.fireWith [as resolveWith] (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils&ver=6.7.2:2:26053)
    at l (load-scripts.php?c=0&load%5Bchunk_0%5D=jquery-core,jquery-migrate,utils&ver=6.7.2:2:77782)
```

For the last release datatables JS library was updated to a slightly newer version, which probably caused the issue.

Looking at the [docs](https://datatables.net/reference/api/draw()), `page` param is probably not what is wanted (since data is changed). I changed it to `full-hold` as that seems to recalc entire table and redraw it.
