### PR TITLE
Do not autoload plugin option

### DIFF
--- a/aaa-option-optimizer.php
+++ b/aaa-option-optimizer.php
@@ -50,7 +50,7 @@ function aaa_option_optimizer_activation() {
 			'starting_point_date' => current_time( 'mysql' ),
 			'used_options'        => [],
 		],
-		true
+		false
 	);
 }
 

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -142,6 +142,6 @@ class Plugin {
 		}
 
 		// Update the 'option_optimizer' option with the new list.
-		update_option( 'option_optimizer', $option_optimizer, true );
+		update_option( 'option_optimizer', $option_optimizer, false );
 	}
 }


### PR DESCRIPTION
## Context

This PR changes ensures the plugin option is not autoloaded, to improve performance.