### PR TITLE
Fix delete / remove or add autoload for options which have dot in their name

### DIFF
--- a/js/admin-script.js
+++ b/js/admin-script.js
@@ -30,6 +30,16 @@ jQuery( document ).ready( function () {
 	} );
 
 	/**
+	 * Generate row ID for an option name.
+	 *
+	 * @param {string} optionName - The option name.
+	 * @return {string} The row ID.
+	 */
+	function generateRowId( optionName ) {
+		return 'option_' + optionName.replace( /\./g, '_' );
+	}
+
+	/**
 	 * Initializes the DataTable for the given selector.
 	 *
 	 * @param {string} selector - The table selector.
@@ -40,6 +50,9 @@ jQuery( document ).ready( function () {
 			autoWidth: false,
 			responsive: true,
 			columns: getColumns( selector ),
+			rowId( data ) {
+				return generateRowId( data.name );
+			},
 			initComplete() {
 				this.api().columns( 'source:name' ).every( setupColumnFilters );
 			},
@@ -55,7 +68,6 @@ jQuery( document ).ready( function () {
 				type: 'GET',
 				dataSrc: 'data',
 			};
-			options.rowId = 'row_id';
 			options.serverSide = true;
 			options.processing = true;
 			options.language = {
@@ -72,7 +84,6 @@ jQuery( document ).ready( function () {
 				type: 'GET',
 				dataSrc: 'data',
 			};
-			options.rowId = 'row_id';
 			options.serverSide = true;
 			options.processing = true;
 			options.language = {
@@ -89,7 +100,6 @@ jQuery( document ).ready( function () {
 				type: 'GET',
 				dataSrc: 'data',
 			};
-			options.rowId = 'row_id';
 			options.serverSide = true;
 			options.processing = true;
 		}
@@ -103,7 +113,6 @@ jQuery( document ).ready( function () {
 				type: 'GET',
 				dataSrc: 'data',
 			};
-			options.rowId = 'row_id';
 		}
 
 		new DataTable( selector, options ).columns.adjust().responsive.recalc();
@@ -367,9 +376,11 @@ jQuery( document ).ready( function () {
 	 * @param {string}    action     - The action performed.
 	 */
 	function updateRowOnSuccess( response, table, optionName, action ) {
+		// Get the row ID for the option name.
+		const rowId = generateRowId( optionName );
 		if ( action === 'delete-option' || action === 'create-option-false' ) {
 			table
-				.row( 'tr#option_' + optionName )
+				.row( 'tr#' + rowId )
 				.remove()
 				.draw( 'full-hold' );
 		} else if (
@@ -390,16 +401,14 @@ jQuery( document ).ready( function () {
 					  aaaOptionOptimizer.i18n.addAutoload +
 					  '</button>';
 
-			jQuery( 'tr#option_' + optionName )
+			jQuery( 'tr#' + rowId )
 				.find( 'td.autoload' )
 				.text( autoloadStatus );
 			const oldButton =
 				'button.' +
 				( action === 'add-autoload' ? 'add' : 'remove' ) +
 				'-autoload';
-			jQuery( 'tr#option_' + optionName + ' ' + oldButton ).replaceWith(
-				buttonHTML
-			);
+			jQuery( 'tr#' + rowId + ' ' + oldButton ).replaceWith( buttonHTML );
 		}
 	}
 

--- a/known-plugins/known-plugins.json
+++ b/known-plugins/known-plugins.json
@@ -93,7 +93,7 @@
     },
     "litespeed-cache": {
         "name": "LiteSpeed Cache",
-        "option_prefixes": ["litespeed-", "_litespeed_"]
+        "option_prefixes": ["litespeed-", "_litespeed_", "litespeed."]
     },
     "loginizer": {
         "name": "Loginizer",

--- a/src/class-rest.php
+++ b/src/class-rest.php
@@ -188,7 +188,6 @@ class REST {
 				'size'     => $this->get_length( $option->option_value ),
 				'raw_size' => strlen( $option->option_value ),
 				'autoload' => $option->autoload,
-				'row_id'   => 'option_' . $option->option_name,
 			];
 		}
 		return new \WP_REST_Response( [ 'data' => $output ], 200 );
@@ -266,7 +265,6 @@ class REST {
 					'size'     => $this->get_length( $row->option_value ),
 					'raw_size' => strlen( $row->option_value ),
 					'autoload' => 'yes',
-					'row_id'   => 'option_' . $row->option_name,
 				];
 			}
 


### PR DESCRIPTION
Came in https://wordpress.org/support/topic/litespeed-autoload/

The issue is comes from Litespeed options having dot in their name, for example `litespeed.admin_display.messages` and it is partly valid.

AAAOO plugin option name to generate the ID of the row (HTML element) for that option in the table, but this is invalid CSS selector: `tr#option_litespeed.admin_display.messages`

So what happens is that option is deleted, but the element can not be found in the table which triggers a JS error that user shared.

Also, looks like litespeed options are recreated on page load so once user refreshes the page option is again displayed and looks like nothing happened.

This PR replaces the dots with `_` (maybe we can use different character for replacement, just needs to make valid CSS selector?) and fixes the issue. Manipulation is done only in JS, doesn't need to be adjusted.