### PR TITLE
Fix HTML & add slashes

### DIFF
--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -94,16 +94,16 @@ class Admin_Page {
 
 		\wp_enqueue_style(
 			'datatables',
-			plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/vendor/datatables.min.css',
+			\plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/vendor/datatables.min.css',
 			[],
 			'2.0.1'
 		);
 
 		\wp_enqueue_script(
 			'aaa-option-optimizer-admin-js',
-			plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/admin-script.js',
+			\plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/admin-script.js',
 			[ 'jquery', 'datatables' ], // Dependencies.
-			filemtime( plugin_dir_path( AAA_OPTION_OPTIMIZER_FILE ) . 'js/admin-script.js' ), // Version.
+			\filemtime( \plugin_dir_path( AAA_OPTION_OPTIMIZER_FILE ) . 'js/admin-script.js' ), // Version.
 			true // In footer.
 		);
 
@@ -111,48 +111,48 @@ class Admin_Page {
 			'aaa-option-optimizer-admin-js',
 			'aaaOptionOptimizer',
 			[
-				'root'  => esc_url_raw( rest_url() ),
-				'nonce' => wp_create_nonce( 'wp_rest' ),
+				'root'  => \esc_url_raw( \rest_url() ),
+				'nonce' => \wp_create_nonce( 'wp_rest' ),
 				'i18n'  => [
-					'filterBySource'         => esc_html__( 'Filter by source', 'aaa-option-optimizer' ),
-					'showValue'              => esc_html__( 'Show', 'aaa-option-optimizer' ),
-					'addAutoload'            => esc_html__( 'Add autoload', 'aaa-option-optimizer' ),
-					'removeAutoload'         => esc_html__( 'Remove autoload', 'aaa-option-optimizer' ),
-					'deleteOption'           => esc_html__( 'Delete', 'aaa-option-optimizer' ),
-					'createOptionFalse'      => esc_html__( 'Create option with value false', 'aaa-option-optimizer' ),
-					'noAutoloadedButNotUsed' => esc_html__( 'All autoloaded options are in use.', 'aaa-option-optimizer' ),
-					'noUsedButNotAutoloaded' => esc_html__( 'All options that are used are autoloaded.', 'aaa-option-optimizer' ),
+					'filterBySource'         => \esc_html__( 'Filter by source', 'aaa-option-optimizer' ),
+					'showValue'              => \esc_html__( 'Show', 'aaa-option-optimizer' ),
+					'addAutoload'            => \esc_html__( 'Add autoload', 'aaa-option-optimizer' ),
+					'removeAutoload'         => \esc_html__( 'Remove autoload', 'aaa-option-optimizer' ),
+					'deleteOption'           => \esc_html__( 'Delete', 'aaa-option-optimizer' ),
+					'createOptionFalse'      => \esc_html__( 'Create option with value false', 'aaa-option-optimizer' ),
+					'noAutoloadedButNotUsed' => \esc_html__( 'All autoloaded options are in use.', 'aaa-option-optimizer' ),
+					'noUsedButNotAutoloaded' => \esc_html__( 'All options that are used are autoloaded.', 'aaa-option-optimizer' ),
 
-					'search'                 => esc_html__( 'Search:', 'aaa-option-optimizer' ),
+					'search'                 => \esc_html__( 'Search:', 'aaa-option-optimizer' ),
 					'entries'                => [
 						'_' => \esc_html__( 'entries', 'aaa-option-optimizer' ),
 						'1' => \esc_html__( 'entry', 'aaa-option-optimizer' ),
 					],
 					'sInfo'                  => sprintf(
 						// translators: %1$s is the start, %2$s is the end, %3$s is the total, %4$s is the entries.
-						esc_html__( 'Showing %1$s to %2$s of %3$s %4$s', 'aaa-option-optimizer' ),
+						\esc_html__( 'Showing %1$s to %2$s of %3$s %4$s', 'aaa-option-optimizer' ),
 						'_START_',
 						'_END_',
 						'_TOTAL_',
 						'_ENTRIES-TOTAL_'
 					),
-					'sInfoEmpty'             => esc_html__( 'Showing 0 to 0 of 0 entries', 'aaa-option-optimizer' ),
+					'sInfoEmpty'             => \esc_html__( 'Showing 0 to 0 of 0 entries', 'aaa-option-optimizer' ),
 					'sInfoFiltered'          => sprintf(
 						// translators: %1$s is the max, %2$s is the entries-max.
-						esc_html__( '(filtered from %1$s total %2$s)', 'aaa-option-optimizer' ),
+						\esc_html__( '(filtered from %1$s total %2$s)', 'aaa-option-optimizer' ),
 						'_MAX_',
 						'_ENTRIES-MAX_'
 					),
-					'sZeroRecords'           => esc_html__( 'No matching records found', 'aaa-option-optimizer' ),
+					'sZeroRecords'           => \esc_html__( 'No matching records found', 'aaa-option-optimizer' ),
 					'oAria'                  => [
-						'orderable'        => esc_html__( ': Activate to sort', 'aaa-option-optimizer' ),
-						'orderableReverse' => esc_html__( ': Activate to invert sorting', 'aaa-option-optimizer' ),
-						'orderableRemove'  => esc_html__( ': Activate to remove sorting', 'aaa-option-optimizer' ),
+						'orderable'        => \esc_html__( ': Activate to sort', 'aaa-option-optimizer' ),
+						'orderableReverse' => \esc_html__( ': Activate to invert sorting', 'aaa-option-optimizer' ),
+						'orderableRemove'  => \esc_html__( ': Activate to remove sorting', 'aaa-option-optimizer' ),
 						'paginate'         => [
-							'first'    => esc_html__( 'First', 'aaa-option-optimizer' ),
-							'last'     => esc_html__( 'Last', 'aaa-option-optimizer' ),
-							'next'     => esc_html__( 'Next', 'aaa-option-optimizer' ),
-							'previous' => esc_html__( 'Previous', 'aaa-option-optimizer' ),
+							'first'    => \esc_html__( 'First', 'aaa-option-optimizer' ),
+							'last'     => \esc_html__( 'Last', 'aaa-option-optimizer' ),
+							'next'     => \esc_html__( 'Next', 'aaa-option-optimizer' ),
+							'previous' => \esc_html__( 'Previous', 'aaa-option-optimizer' ),
 						],
 					],
 				],
@@ -203,133 +203,136 @@ class Admin_Page {
 	 * @return void
 	 */
 	public function render_admin_page_ajax() {
-		$option_optimizer = get_option( 'option_optimizer', [ 'used_options' => [] ] );
-
-		// Start HTML output.
-		echo '<div class="wrap"><h1>' . esc_html__( 'AAA Option Optimizer', 'aaa-option-optimizer' ) . '</h1>';
+		$option_optimizer = \get_option( 'option_optimizer', [ 'used_options' => [] ] );
 
 		global $wpdb;
 		$autoload_values = \wp_autoload_values_to_autoload();
-		$placeholders    = implode( ',', array_fill( 0, count( $autoload_values ), '%s' ) );
+		$placeholders    = \implode( ',', \array_fill( 0, \count( $autoload_values ), '%s' ) );
 
 		// phpcs:disable WordPress.DB
 		$result = $wpdb->get_row(
 			$wpdb->prepare( "SELECT count(*) AS count, SUM( LENGTH( option_value ) ) as autoload_size FROM {$wpdb->options} WHERE autoload IN ( $placeholders )", $autoload_values )
 		);
 		// phpcs:enable WordPress.DB
+		?>
+		<div class="wrap">
+			<h1><?php \esc_html_e( 'AAA Option Optimizer', 'aaa-option-optimizer' ); ?></h1>
 
-		echo '<h2>' . esc_html__( 'Stats', 'aaa-option-optimizer' ) . '</h2>';
-		echo '<p>' .
-			sprintf(
-				// translators: %1$s is the date, %2$s is the number of options at stat, %3$s is the size at start in KB, %4$s is the number of options now, %5$s is the size in KB now.
-				esc_html__( 'When you started on %1$s you had %2$s autoloaded options, for %3$sKB of memory. Now you have %4$s options, for %5$sKB of memory.', 'aaa-option-optimizer' ),
-				esc_html( gmdate( 'Y-m-d', strtotime( $option_optimizer['starting_point_date'] ) ) ),
-				isset( $option_optimizer['starting_point_num'] ) ? esc_html( $option_optimizer['starting_point_num'] ) : '-',
-				number_format( ( $option_optimizer['starting_point_kb'] ), 1 ),
-				esc_html( $result->count ),
-				number_format( ( $result->autoload_size / 1024 ), 1 )
-			) . '</p>';
+			<h2><?php \esc_html_e( 'Stats', 'aaa-option-optimizer' ); ?></h2>
+			<p>
+				<?php
+				printf(
+					// translators: %1$s is the date, %2$s is the number of options at stat, %3$s is the size at start in KB, %4$s is the number of options now, %5$s is the size in KB now.
+					\esc_html__( 'When you started on %1$s you had %2$s autoloaded options, for %3$sKB of memory. Now you have %4$s options, for %5$sKB of memory.', 'aaa-option-optimizer' ),
+					\esc_html( \gmdate( 'Y-m-d', \strtotime( $option_optimizer['starting_point_date'] ) ) ),
+					isset( $option_optimizer['starting_point_num'] ) ? \esc_html( $option_optimizer['starting_point_num'] ) : '-',
+					\number_format( ( $option_optimizer['starting_point_kb'] ), 1 ),
+					\esc_html( $result->count ),
+					\number_format( ( $result->autoload_size / 1024 ), 1 )
+				);
+				?>
+			</p>
 
-		echo '<h2>' . esc_html__( 'Optimize', 'aaa-option-optimizer' ) . '</h2>';
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce is used for REST API.
-		if ( isset( $_GET['tracking_reset'] ) && $_GET['tracking_reset'] === 'true' ) {
-			echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Tracking data has been reset.', 'aaa-option-optimizer' ) . '</p></div>';
-			// Take the parameter out of the URL without reloading the page.
-			echo '<script>window.history.pushState({}, document.title, window.location.href.replace( \'&tracking_reset=true\', \'\' ) );</script>';
-		}
-		echo '<div class="aaa-option-optimizer-reset"><button id="aaa-option-reset-data" class="button button-delete reset-data">' . esc_html__( 'Reset data', 'aaa-option-optimizer' ) . '</button></div>';
-		echo '<p>' . esc_html__( 'We\'ve found the following things you can maybe optimize:', 'aaa-option-optimizer' ) . '</p>';
+			<h2><?php \esc_html_e( 'Optimize', 'aaa-option-optimizer' ); ?></h2>
+			<?php
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce is used for REST API.
+			if ( isset( $_GET['tracking_reset'] ) && $_GET['tracking_reset'] === 'true' ) :
+				?>
+				<div class="notice notice-success is-dismissible">
+					<p><?php \esc_html_e( 'Tracking data has been reset.', 'aaa-option-optimizer' ); ?></p>
+				</div>
+				<?php // Take the parameter out of the URL without reloading the page. ?>
+				<script>window.history.pushState({}, document.title, window.location.href.replace( '&tracking_reset=true', '' ) );</script>
+			<?php endif; ?>
 
-		?>
-	<div class="aaa-option-optimizer-tabs">
-			<input class="input" name="tabs" type="radio" id="tab-1" checked="checked"/>
-			<label class="label" for="tab-1"><?php esc_html_e( 'Unused, but autoloaded', 'aaa-option-optimizer' ); ?></label>
-			<div class="panel">
-		<?php
-		echo '<h2 id="unused-autoloaded">' . esc_html__( 'Unused, but autoloaded', 'aaa-option-optimizer' ) . '</h2>';
-		echo '<p>' . esc_html__( 'The following options are autoloaded on each pageload, but AAA Option Optimizer has not been able to detect them being used.', 'aaa-option-optimizer' );
-		echo '<table style="width:100%" id="unused_options_table" class="aaa_option_table">';
-		$this->table_section( 'thead', [ 'option', 'source', 'size', 'autoload', 'actions' ] );
-		?>
-		<tbody>
-		<tr>
-			<td></td>
-			<td></td>
-			<td></td>
-			<td></td>
-			<td class="actions"></td>
-		</tr>
-		</tbody>
-		<?php
-		$this->table_section( 'tfoot', [ 'option', 'source', 'size', 'autoload', 'actions' ] );
-		?>
-		</table>
+			<div class="aaa-option-optimizer-reset">
+				<button id="aaa-option-reset-data" class="button button-delete reset-data">
+					<?php \esc_html_e( 'Reset data', 'aaa-option-optimizer' ); ?>
+				</button>
+			</div>
+			<p><?php \esc_html_e( 'We\'ve found the following things you can maybe optimize:', 'aaa-option-optimizer' ); ?></p>
+
+			<div class="aaa-option-optimizer-tabs">
+				<input class="input" name="tabs" type="radio" id="tab-1" checked="checked"/>
+				<label class="label" for="tab-1"><?php \esc_html_e( 'Unused, but autoloaded', 'aaa-option-optimizer' ); ?></label>
+				<div class="panel">
+					<h2 id="unused-autoloaded"><?php \esc_html_e( 'Unused, but autoloaded', 'aaa-option-optimizer' ); ?></h2>
+					<p><?php \esc_html_e( 'The following options are autoloaded on each pageload, but AAA Option Optimizer has not been able to detect them being used.', 'aaa-option-optimizer' ); ?></p>
+
+					<table style="width:100%" id="unused_options_table" class="aaa_option_table">
+						<?php $this->table_section( 'thead', [ 'option', 'source', 'size', 'autoload', 'actions' ] ); ?>
+						<tbody>
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td class="actions"></td>
+							</tr>
+						</tbody>
+						<?php $this->table_section( 'tfoot', [ 'option', 'source', 'size', 'autoload', 'actions' ] ); ?>
+					</table>
+				</div>
+				<input class="input" name="tabs" type="radio" id="tab-2"/>
+				<label class="label" for="tab-2"><?php \esc_html_e( 'Used, but not autoloaded', 'aaa-option-optimizer' ); ?></label>
+				<div class="panel">
+					<?php // Render differences. ?>
+					<h2 id="used-not-autoloaded"><?php \esc_html_e( 'Used, but not autoloaded options', 'aaa-option-optimizer' ); ?></h2>
+					<p><?php \esc_html_e( 'The following options are *not* autoloaded on each pageload, but AAA Option Optimizer has detected that they are being used. If one of the options below has been called a lot and is not very big, you might consider adding autoload to that option.', 'aaa-option-optimizer' ); ?></p>
+					<table style="width:100%;" id="used_not_autoloaded_table" class="aaa_option_table">
+						<?php $this->table_section( 'thead', [ 'option', 'source', 'size', 'autoload', 'calls', 'actions' ] ); ?>
+						<tbody>
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td class="actions"></td>
+							</tr>
+						</tbody>
+						<?php $this->table_section( 'tfoot', [ 'option', 'source', 'size', 'autoload', 'calls', 'actions' ] ); ?>
+					</table>
+				</div>
+				<input class="input" name="tabs" type="radio" id="tab-3"/>
+				<label class="label" for="tab-3"><?php \esc_html_e( 'Requested options that do not exist', 'aaa-option-optimizer' ); ?></label>
+				<div class="panel">
+					<h2 id="requested-do-not-exist"><?php \esc_html_e( 'Requested options that do not exist', 'aaa-option-optimizer' ); ?></h2>
+					<p><?php \esc_html_e( 'The following options are requested sometimes, but AAA Option Optimizer has detected that they do not exist. If one of the options below has been called a lot, it might help to create it with a value of false.', 'aaa-option-optimizer' ); ?></p>
+					<table width="100%" id="requested_do_not_exist_table" class="aaa_option_table">
+						<?php $this->table_section( 'thead', [ 'option', 'source', 'calls', 'actions' ] ); ?>
+						<tbody>
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td class="actions"></td>
+							</tr>
+						</tbody>
+						<?php $this->table_section( 'tfoot', [ 'option', 'source', 'calls', 'actions' ] ); ?>
+					</table>
+				</div>
+				<input class="input" name="tabs" type="radio" id="tab-4"/>
+				<label class="label" for="tab-4"><?php \esc_html_e( 'All options', 'aaa-option-optimizer' ); ?></label>
+				<div class="panel">
+					<p><?php \esc_html_e( 'If you want to browse all the options in the database, you can do so here:', 'aaa-option-optimizer' ); ?></p>
+					<button id="aaa_get_all_options" class="button button-primary"><?php \esc_html_e( 'Get all options', 'aaa-option-optimizer' ); ?></button>
+					<table class="aaa_option_table" id="all_options_table" style="display:none;">
+						<?php $this->table_section( 'thead', [ 'option', 'source', 'size', 'autoload', 'actions' ] ); ?>
+						<tbody>
+							<tr>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td></td>
+								<td class="actions"></td>
+							</tr>
+						</tbody>
+						<?php $this->table_section( 'tfoot', [ 'option', 'source', 'size', 'autoload', 'actions' ] ); ?>
+					</table>
+				</div>
+			</div>
 		</div>
-		<input class="input" name="tabs" type="radio" id="tab-2"/>
-			<label class="label" for="tab-2"><?php esc_html_e( 'Used, but not autoloaded', 'aaa-option-optimizer' ); ?></label>
-			<div class="panel">
-		<?php
-		// Render differences.
-			echo '<h2 id="used-not-autoloaded">' . esc_html__( 'Used, but not autoloaded options', 'aaa-option-optimizer' ) . '</h2>';
-			echo '<p>' . esc_html__( 'The following options are *not* autoloaded on each pageload, but AAA Option Optimizer has detected that they are being used. If one of the options below has been called a lot and is not very big, you might consider adding autoload to that option.', 'aaa-option-optimizer' );
-			echo '<table style="width:100%;" id="used_not_autoloaded_table" class="aaa_option_table">';
-			$this->table_section( 'thead', [ 'option', 'source', 'size', 'autoload', 'calls', 'actions' ] );
-		?>
-			<tbody>
-			<tr>
-				<td></td>
-				<td></td>
-				<td></td>
-				<td></td>
-				<td></td>
-				<td class="actions"></td>
-			</tr>
-			</tbody>
-			<?php $this->table_section( 'tfoot', [ 'option', 'source', 'size', 'autoload', 'calls', 'actions' ] ); ?>
-		</table>
-		</div>
-		<input class="input" name="tabs" type="radio" id="tab-3"/>
-			<label class="label" for="tab-3"><?php esc_html_e( 'Requested options that do not exist', 'aaa-option-optimizer' ); ?></label>
-			<div class="panel">
-		<?php
-		echo '<h2 id="requested-do-not-exist">' . esc_html__( 'Requested options that do not exist', 'aaa-option-optimizer' ) . '</h2>';
-		echo '<p>' . esc_html__( 'The following options are requested sometimes, but AAA Option Optimizer has detected that they do not exist. If one of the options below has been called a lot, it might help to create it with a value of false.', 'aaa-option-optimizer' );
-		echo '<table width="100%" id="requested_do_not_exist_table" class="aaa_option_table">';
-		$this->table_section( 'thead', [ 'option', 'source', 'calls', 'actions' ] );
-		?>
-		<tbody>
-		<tr>
-			<td></td>
-			<td></td>
-			<td></td>
-			<td class="actions"></td>
-		</tr>
-		</tbody>
-		<?php
-		$this->table_section( 'tfoot', [ 'option', 'source', 'calls', 'actions' ] );
-		?>
-		</table>
-		</div>
-		<input class="input" name="tabs" type="radio" id="tab-4"/>
-		<label class="label" for="tab-4"><?php esc_html_e( 'All options', 'aaa-option-optimizer' ); ?></label>
-		<div class="panel">
-			<p><?php esc_html_e( 'If you want to browse all the options in the database, you can do so here:', 'aaa-option-optimizer' ); ?></p>
-			<button id="aaa_get_all_options" class="button button-primary"><?php esc_html_e( 'Get all options', 'aaa-option-optimizer' ); ?></button>
-			<table class="aaa_option_table" id="all_options_table" style="display:none;">
-				<?php $this->table_section( 'thead', [ 'option', 'source', 'size', 'autoload', 'actions' ] ); ?>
-				<tbody>
-					<tr>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td></td>
-						<td class="actions"></td>
-					</tr>
-				</tbody>
-				<?php $this->table_section( 'tfoot', [ 'option', 'source', 'size', 'autoload', 'actions' ] ); ?>
-			</table>
-		</div>
-	</div>
 		<?php
 	}
 }


### PR DESCRIPTION
We were using things like `echo '<p>foo` instead of 
```php
?>
<p>foo</p>
<?php
```
The result is that there were a couple of unclosed PHP tags that were missed, and the structure was not as clear as it should have been.
This PR changes the way we write HTML to be rendered. This allows us to:
* Properly indent HTML so the structure is easier to understand visually
* Visually inspect the code for anything missing, with proper highlighting of elements in code-editors