### PR TITLE
Prefix Datatables script slug

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ Install this plugin, and go through your entire site. Best is to use it normally
 
 = Why the AAA prefix in the plugin name? =
 
-Because the plugin needs to measure options being loaded, it benefits from being loaded itself first. As WordPress loads plugins alphabetically, 
+Because the plugin needs to measure options being loaded, it benefits from being loaded itself first. As WordPress loads plugins alphabetically,
 starting the name with AAA made sense.
 
 = Do I need to take precautions? =
@@ -53,6 +53,10 @@ Please do a pull request via GitHub on [this file](https://github.com/Emilia-Cap
 2. Screenshot of the "All options" screen, showing you can browse all the options.
 
 == Changelog ==
+
+= 1.5.0 =
+
+* Prefix the Datatables script slug to avoid conflict with other plugins.
 
 = 1.4.0 =
 
@@ -95,7 +99,7 @@ Implement the missing functionality to create an option with value `false` when 
 
 = 1.1 =
 
-The plugin now recognizes plugins from which the options came (thanks to a great pull by [Rogier Lankhorst](https://profiles.wordpress.org/rogierlankhorst/)). If you're a plugin developer and want your plugin's options 
+The plugin now recognizes plugins from which the options came (thanks to a great pull by [Rogier Lankhorst](https://profiles.wordpress.org/rogierlankhorst/)). If you're a plugin developer and want your plugin's options
 properly recognized, please do a pull request [on this file](https://github.com/Emilia-Capital/aaa-option-optimizer/blob/main/known-plugins/known-plugins.json).
 
 Small enhancements:

--- a/src/class-admin-page.php
+++ b/src/class-admin-page.php
@@ -85,7 +85,7 @@ class Admin_Page {
 		);
 
 		\wp_enqueue_script(
-			'datatables',
+			'aaaoo-datatables',
 			plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/vendor/datatables.min.js',
 			[], // Dependencies.
 			'2.3.2',
@@ -93,7 +93,7 @@ class Admin_Page {
 		);
 
 		\wp_enqueue_style(
-			'datatables',
+			'aaaoo-datatables',
 			\plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/vendor/datatables.min.css',
 			[],
 			'2.3.2'
@@ -102,7 +102,7 @@ class Admin_Page {
 		\wp_enqueue_script(
 			'aaa-option-optimizer-admin-js',
 			\plugin_dir_url( AAA_OPTION_OPTIMIZER_FILE ) . 'js/admin-script.js',
-			[ 'jquery', 'datatables' ], // Dependencies.
+			[ 'jquery', 'aaaoo-datatables' ], // Dependencies.
 			\filemtime( \plugin_dir_path( AAA_OPTION_OPTIMIZER_FILE ) . 'js/admin-script.js' ), // Version.
 			true // In footer.
 		);


### PR DESCRIPTION
Plugin uses datatables script for displaying options in the table, but when the script is enqueued it's slug is [not prefixed](https://github.com/Emilia-Capital/aaa-option-optimizer/blob/32d3b5cb8fc3b97f1afde15594e3b9e21c40472d/src/class-admin-page.php#L87-L108). 

This makes a problem if other plugins are using the same script also without the slug prefix, since the different version of the script gets enqueued.